### PR TITLE
Support for integer

### DIFF
--- a/src/loiste/core.clj
+++ b/src/loiste/core.clj
@@ -126,6 +126,9 @@
   java.lang.Double
   (-write [value ^Cell cell options]
     (.setCellValue cell value))
+  java.lang.Float
+  (-write [value ^Cell cell options]
+    (.setCellValue cell (double value)))
   java.lang.Boolean
   (-write [value ^Cell cell options]
     (.setCellValue cell value))

--- a/src/loiste/core.clj
+++ b/src/loiste/core.clj
@@ -135,6 +135,18 @@
   java.lang.Long
   (-write [value ^Cell cell options]
     (.setCellValue cell (double value)))
+  java.lang.Integer
+  (-write [value ^Cell cell options]
+    (.setCellValue cell (double value)))
+  java.lang.Short
+  (-write [value ^Cell cell options]
+    (.setCellValue cell (double value)))
+  java.lang.Byte
+  (-write [value ^Cell cell options]
+    (.setCellValue cell (double value)))
+  clojure.lang.Named
+  (-write [value ^Cell cell options]
+    (.setCellValue cell (name value)))
   clojure.lang.IPersistentMap
   (-write [value ^Cell cell options]
     (if (:style value)

--- a/src/loiste/core.clj
+++ b/src/loiste/core.clj
@@ -123,10 +123,7 @@
   java.lang.String
   (-write [value ^Cell cell options]
     (.setCellValue cell value))
-  java.lang.Double
-  (-write [value ^Cell cell options]
-    (.setCellValue cell value))
-  java.lang.Float
+  java.lang.Number
   (-write [value ^Cell cell options]
     (.setCellValue cell (double value)))
   java.lang.Boolean
@@ -135,18 +132,6 @@
   java.util.Date
   (-write [value ^Cell cell options]
     (.setCellValue cell value))
-  java.lang.Long
-  (-write [value ^Cell cell options]
-    (.setCellValue cell (double value)))
-  java.lang.Integer
-  (-write [value ^Cell cell options]
-    (.setCellValue cell (double value)))
-  java.lang.Short
-  (-write [value ^Cell cell options]
-    (.setCellValue cell (double value)))
-  java.lang.Byte
-  (-write [value ^Cell cell options]
-    (.setCellValue cell (double value)))
   clojure.lang.Named
   (-write [value ^Cell cell options]
     (.setCellValue cell (name value)))

--- a/test/loiste/core_test.clj
+++ b/test/loiste/core_test.clj
@@ -86,6 +86,8 @@
                   :value "This is a long text that should wrap"}
                  #inst "2016-03-09T14:05:00"]}
        ["Bar" #inst "2016-03-09T14:05:00"]
-       ["Qux" 100000]])
+       ["Qux" 100000]
+       ["Integer" (count '(1 2 3))]
+       ["Keyword" :foo]])
     (l/to-file! file test-workbook)
     file))


### PR DESCRIPTION
Currently writing cells with integer values fails. This happens surprisingly often, as some of the
core fn's return integers. For example, `(type (count [1 2 3]))` is `java.lang.Integer`.

This PR adds support for Integer, Short and Byte and Float.

Also, writing clojure.lang.Named is supported (for example keywords).
