### PR TITLE
Write nil values as blank cells insted of empty strings

### DIFF
--- a/src/loiste/core.clj
+++ b/src/loiste/core.clj
@@ -168,7 +168,7 @@
     (-write (:value value) cell options))
   nil
   (-write [value ^Cell cell options]
-    (.setCellValue cell "")))
+    (.setBlank cell)))
 
 (defn write-cell! [^Cell cell {:keys [style] :as options} value]
   (if style

--- a/test/loiste/core_test.clj
+++ b/test/loiste/core_test.clj
@@ -48,7 +48,7 @@
 
       (testing "parse the written data"
         (is (= [{:A "Foo" :B true :C 1.0}
-                {:A "Bar" :B ""   :C 2.0}]
+                {:A "Bar" :B nil   :C 2.0}]
                (rest (l/sheet->map test-spec sheet)))))
 
       file)))
@@ -99,7 +99,7 @@
                 {:Stuff "Bar" :Date #inst "2016-03-09T14:05:00" :Money 15.0}
                 {:Stuff "Qux" :Date #inst "2173-10-13T21:00:00.000-00:00" :Money 100.0}
                 {:Stuff "Integer" :Date #inst "1900-01-02T22:20:11.000-00:00" :Money 10000.0}
-                {:Stuff "Keyword" :Date "foo" :Money ""}]
+                {:Stuff "Keyword" :Date "foo" :Money nil}]
                (l/read-sheet read-sheet)))))
 
     (.delete file)))


### PR DESCRIPTION
Insted of writing nil values as empty strings to an excel cell, set the cell blank.
https://poi.apache.org/apidocs/dev/org/apache/poi/ss/usermodel/Cell.html#setBlank--